### PR TITLE
Hide grammatical mistake in LICENSE file

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 THE "LITTLE SUS DISTRO" (LSD) LICENSE, VERSION 1.1
 
-Copyright (c) 2021 Michael Zheng, Moon1789 and the AmogOS Contributors. All rights reserved.
+Copyright (c) 2023 NoozAbooz, Moon1789 and the AmogOS Contributors. All rights reserved.
 
 
 RECOMMENDATION

--- a/LICENSE
+++ b/LICENSE
@@ -1,4 +1,4 @@
-THE "LITTLE SUS DISTRO" (LSD) LICENSE, VERSION 1
+THE "LITTLE SUS DISTRO" (LSD) LICENSE, VERSION 1.1
 
 Copyright (c) 2021 Michael Zheng, Moon1789 and the AmogOS Contributors. All rights reserved.
 
@@ -6,7 +6,7 @@ Copyright (c) 2021 Michael Zheng, Moon1789 and the AmogOS Contributors. All righ
 RECOMMENDATION
 
 It is a non-binding recommendation of this license that any redistributions
-of this work should be free-of-charge due to it's nature as a work of
+of this work should be free-of-charge due to its nature as a work of
 parody.
 
 
@@ -26,7 +26,7 @@ are permitted provided that the following conditions are met:
     software must display the following acknowledgement:
     This product includes software developed by the AmogOS Project.
     
-    4. Neither the name "AmogOS" nor the names of its
+    4. Neither the name "AmogOS" nor the names of it's
     contributors may be used to endorse or promote products derived
     from this software without specific prior written permission.
 


### PR DESCRIPTION
There was a mistake, so I moved it to a different portion of the license to obey the natural law of conservation of typos.